### PR TITLE
Polish for rpi3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,7 @@
-FROM resin/raspberrypi2-debian:jessie
+FROM resin/raspberrypi3-debian:jessie-slim
 
 # Add the key for foundation repository
-RUN apt-get update
-RUN apt-get install wget
-RUN wget http://archive.raspberrypi.org/debian/raspberrypi.gpg.key -O - | sudo apt-key add -
-
-# Add apt source of the foundation repository
-# We need this source because bluez needs to be patched in order to work with rpi3 ( Issue #1314: How to get BT working on Pi3B. by clivem in raspberrypi/linux on GitHub )
-# Add it on top so apt will pick up packages from there
-RUN sed -i '1s#^#deb http://archive.raspberrypi.org/debian jessie main\n#' /etc/apt/sources.list
-RUN apt-get update
-
-# Install required packages
-RUN apt-get install bluez bluez-firmware
+RUN apt-get update && apt-get install bluez bluez-firmware
 
 WORKDIR usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi3-debian:jessie-slim
+FROM resin/raspberrypi3-debian:jessie
 
 # Add the key for foundation repository
 RUN apt-get update && apt-get install bluez bluez-firmware


### PR DESCRIPTION
all the workarounds contained in this project are no longer required because bluez-firmware is now upstream.
Also, app now targets raspberrypi3 base image, since the test case targets that device type.

the polishing got the container to go from ~260 to ~190 MB and the build time from ~3.5 mins to ~1.5 mins